### PR TITLE
OSPC-2091:Added the changes for the Maintenance & Notification Banner

### DIFF
--- a/skyline_apiserver/api/v1/__init__.py
+++ b/skyline_apiserver/api/v1/__init__.py
@@ -14,7 +14,15 @@
 
 from fastapi import APIRouter
 
-from skyline_apiserver.api.v1 import contrib, extension, login, policy, prometheus, setting
+from skyline_apiserver.api.v1 import (
+    contrib,
+    extension,
+    login,
+    message_banner,
+    policy,
+    prometheus,
+    setting,
+)
 
 api_router = APIRouter()
 api_router.include_router(login.router, tags=["Login"])
@@ -23,3 +31,4 @@ api_router.include_router(prometheus.router, tags=["Prometheus"])
 api_router.include_router(contrib.router, tags=["Contrib"])
 api_router.include_router(policy.router, tags=["Policy"])
 api_router.include_router(setting.router, tags=["Setting"])
+api_router.include_router(message_banner.router, tags=["Message Banner"])

--- a/skyline_apiserver/api/v1/message_banner.py
+++ b/skyline_apiserver/api/v1/message_banner.py
@@ -1,0 +1,292 @@
+# Copyright 2021 99cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import time
+
+from fastapi import status
+from fastapi.exceptions import HTTPException
+from fastapi.param_functions import Depends
+from fastapi.routing import APIRouter
+
+from skyline_apiserver import schemas
+from skyline_apiserver.api import deps
+from skyline_apiserver.db import api as db_api
+from skyline_apiserver.utils.rackspace_status import (
+    fetch_rackspace_status_message_banner_values,
+)
+from skyline_apiserver.utils.roles import assert_system_admin
+
+router = APIRouter()
+RACKSPACE_STATUS_SYNC_INTERVAL = 300
+_rackspace_status_last_sync = 0.0
+
+
+def _format_message_banner(message_banner) -> schemas.MessageBanner:
+    if isinstance(message_banner, schemas.MessageBanner):
+        return message_banner
+    if isinstance(message_banner, dict):
+        return schemas.MessageBanner(**message_banner)
+    return schemas.MessageBanner(**dict(message_banner._mapping))
+
+
+def _format_message_banners(message_banners) -> schemas.MessageBanners:
+    return schemas.MessageBanners(
+        message_banners=[
+            _format_message_banner(message_banner) for message_banner in message_banners
+        ]
+    )
+
+
+def _assert_message_banner_exist(banner_id: str):
+    message_banner = db_api.get_message_banner(banner_id)
+    if message_banner is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Message banner not found.",
+        )
+    return message_banner
+
+
+def _model_dump(model) -> dict:
+    return model.model_dump()
+
+
+def _sync_rackspace_status_feed(force: bool = False) -> None:
+    global _rackspace_status_last_sync
+
+    now = time.time()
+    if not force and now - _rackspace_status_last_sync < RACKSPACE_STATUS_SYNC_INTERVAL:
+        return
+
+    for values in fetch_rackspace_status_message_banner_values():
+        db_api.sync_servicenow_ext_message_banner(values)
+    _rackspace_status_last_sync = now
+
+
+def _assert_same_region(message_banner, profile: schemas.Profile) -> None:
+    region = getattr(message_banner, "region", None)
+    if region and region != profile.region:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not allowed to manage message banners for another region.",
+        )
+
+
+def _manual_message_values(message_banner, profile: schemas.Profile) -> dict:
+    values = _model_dump(message_banner)
+    region = values.get("region") or profile.region
+    if region != profile.region:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not allowed to create message banners for another region.",
+        )
+    values.update(
+        {
+            "project_id": profile.project.id,
+            "region": region,
+            "source": "manual",
+            "source_id": None,
+            "source_url": None,
+        }
+    )
+    return values
+
+
+def _message_update_values(message_banner, existing_message_banner, profile) -> dict:
+    values = _model_dump(message_banner)
+    region = values.get("region") or existing_message_banner.region or profile.region
+    if region != profile.region:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not allowed to update message banners for another region.",
+        )
+
+    values["region"] = region
+    if existing_message_banner.source != "manual":
+        values.update(
+            {
+                "source": existing_message_banner.source,
+                "source_id": existing_message_banner.source_id,
+                "source_url": existing_message_banner.source_url,
+            }
+        )
+        return values
+
+    values.update(
+        {
+            "source": "manual",
+            "source_id": None,
+            "source_url": None,
+        }
+    )
+    return values
+
+
+@router.get(
+    "/message-banners/active",
+    description="Get active dashboard message banners.",
+    responses={
+        200: {"model": schemas.MessageBanners},
+        401: {"model": schemas.UnauthorizedMessage},
+    },
+    response_model=schemas.MessageBanners,
+    status_code=status.HTTP_200_OK,
+    response_description="OK",
+)
+def list_active_message_banners(
+    profile: schemas.Profile = Depends(deps.get_profile_update_jwt),
+) -> schemas.MessageBanners:
+    project_id = profile.project.id
+    _sync_rackspace_status_feed()
+    banners = db_api.list_active_message_banners(
+        project_id=project_id,
+        region=profile.region,
+    )
+    return _format_message_banners(banners)
+
+
+@router.get(
+    "/message-banners",
+    description="Get all message banners.",
+    responses={
+        200: {"model": schemas.MessageBanners},
+        401: {"model": schemas.UnauthorizedMessage},
+        403: {"model": schemas.ForbiddenMessage},
+    },
+    response_model=schemas.MessageBanners,
+    status_code=status.HTTP_200_OK,
+    response_description="OK",
+)
+def list_message_banners(
+    profile: schemas.Profile = Depends(deps.get_profile_update_jwt),
+) -> schemas.MessageBanners:
+    assert_system_admin(
+        profile=profile,
+        exception="Not allowed to list message banners.",
+    )
+    _sync_rackspace_status_feed()
+    banners = db_api.list_message_banners(region=profile.region)
+    return _format_message_banners(banners)
+
+
+@router.get(
+    "/message-banners/{banner_id}",
+    description="Get a message banner.",
+    responses={
+        200: {"model": schemas.MessageBanner},
+        401: {"model": schemas.UnauthorizedMessage},
+        403: {"model": schemas.ForbiddenMessage},
+        404: {"model": schemas.NotFoundMessage},
+    },
+    response_model=schemas.MessageBanner,
+    status_code=status.HTTP_200_OK,
+    response_description="OK",
+)
+def show_message_banner(
+    banner_id: str,
+    profile: schemas.Profile = Depends(deps.get_profile_update_jwt),
+) -> schemas.MessageBanner:
+    assert_system_admin(
+        profile=profile,
+        exception="Not allowed to get message banners.",
+    )
+    message_banner = _assert_message_banner_exist(banner_id)
+    _assert_same_region(message_banner, profile)
+    return _format_message_banner(message_banner)
+
+
+@router.post(
+    "/message-banners",
+    description="Create a message banner.",
+    responses={
+        200: {"model": schemas.MessageBanner},
+        401: {"model": schemas.UnauthorizedMessage},
+        403: {"model": schemas.ForbiddenMessage},
+    },
+    response_model=schemas.MessageBanner,
+    status_code=status.HTTP_200_OK,
+    response_description="OK",
+)
+def create_message_banner(
+    message_banner: schemas.CreateMessageBanner,
+    profile: schemas.Profile = Depends(deps.get_profile_update_jwt),
+) -> schemas.MessageBanner:
+    assert_system_admin(
+        profile=profile,
+        exception="Not allowed to create message banners.",
+    )
+    new_message_banner = db_api.create_message_banner(
+        _manual_message_values(message_banner, profile)
+    )
+    return _format_message_banner(new_message_banner)
+
+
+@router.put(
+    "/message-banners/{banner_id}",
+    description="Update a message banner.",
+    responses={
+        200: {"model": schemas.MessageBanner},
+        401: {"model": schemas.UnauthorizedMessage},
+        403: {"model": schemas.ForbiddenMessage},
+        404: {"model": schemas.NotFoundMessage},
+    },
+    response_model=schemas.MessageBanner,
+    status_code=status.HTTP_200_OK,
+    response_description="OK",
+)
+def update_message_banner(
+    banner_id: str,
+    message_banner: schemas.UpdateMessageBanner,
+    profile: schemas.Profile = Depends(deps.get_profile_update_jwt),
+) -> schemas.MessageBanner:
+    assert_system_admin(
+        profile=profile,
+        exception="Not allowed to update message banners.",
+    )
+    existing_message_banner = _assert_message_banner_exist(banner_id)
+    _assert_same_region(existing_message_banner, profile)
+    updated_message_banner = db_api.update_message_banner(
+        banner_id,
+        _message_update_values(message_banner, existing_message_banner, profile),
+    )
+    return _format_message_banner(updated_message_banner)
+
+
+@router.delete(
+    "/message-banners/{banner_id}",
+    description="Delete a message banner.",
+    responses={
+        200: {"model": schemas.MessageBanner},
+        401: {"model": schemas.UnauthorizedMessage},
+        403: {"model": schemas.ForbiddenMessage},
+        404: {"model": schemas.NotFoundMessage},
+    },
+    response_model=schemas.MessageBanner,
+    status_code=status.HTTP_200_OK,
+    response_description="OK",
+)
+def delete_message_banner(
+    banner_id: str,
+    profile: schemas.Profile = Depends(deps.get_profile_update_jwt),
+) -> schemas.MessageBanner:
+    assert_system_admin(
+        profile=profile,
+        exception="Not allowed to delete message banners.",
+    )
+    existing_message_banner = _assert_message_banner_exist(banner_id)
+    _assert_same_region(existing_message_banner, profile)
+    deleted_message_banner = db_api.delete_message_banner(banner_id)
+    return _format_message_banner(deleted_message_banner)

--- a/skyline_apiserver/db/alembic/versions/001_add_message_banners.py
+++ b/skyline_apiserver/db/alembic/versions/001_add_message_banners.py
@@ -1,0 +1,114 @@
+# Copyright 2021 99cloud
+#
+# Licensed under the Apache License, Version 2.0
+
+"""add message banners
+
+Revision ID: 001
+Revises: 000
+Create Date: 2026-05-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "001"
+down_revision = "000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message_banners",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("type", sa.String(length=32), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("impacted_service", sa.String(length=255), nullable=True),
+        sa.Column("start_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("project_id", sa.String(length=128), nullable=True),
+        sa.Column("region", sa.String(length=255), nullable=True),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=True),
+        sa.Column("source_url", sa.String(length=1024), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_message_banners_type"),
+        "message_banners",
+        ["type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_banners_start_at"),
+        "message_banners",
+        ["start_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_banners_expires_at"),
+        "message_banners",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_banners_project_id"),
+        "message_banners",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_banners_region"),
+        "message_banners",
+        ["region"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_banners_source"),
+        "message_banners",
+        ["source"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_banners_source_id"),
+        "message_banners",
+        ["source_id"],
+        unique=False,
+    )
+    op.create_table(
+        "deleted_external_message_banners",
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("region", sa.String(length=255), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("source", "source_id"),
+    )
+    op.create_index(
+        op.f("ix_deleted_external_message_banners_region"),
+        "deleted_external_message_banners",
+        ["region"],
+        unique=False,
+    )
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_deleted_external_message_banners_region"),
+        table_name="deleted_external_message_banners",
+    )
+    op.drop_table("deleted_external_message_banners")
+    op.drop_index(op.f("ix_message_banners_source_id"), table_name="message_banners")
+    op.drop_index(op.f("ix_message_banners_source"), table_name="message_banners")
+    op.drop_index(op.f("ix_message_banners_region"), table_name="message_banners")
+    op.drop_index(op.f("ix_message_banners_project_id"), table_name="message_banners")
+    op.drop_index(op.f("ix_message_banners_expires_at"), table_name="message_banners")
+    op.drop_index(op.f("ix_message_banners_start_at"), table_name="message_banners")
+    op.drop_index(op.f("ix_message_banners_type"), table_name="message_banners")
+    op.drop_table("message_banners")

--- a/skyline_apiserver/db/api.py
+++ b/skyline_apiserver/db/api.py
@@ -15,15 +15,26 @@
 from __future__ import annotations
 
 import time
+import uuid
+from datetime import datetime, timezone
 from functools import wraps
-from typing import Any, Union
+from typing import Any, Dict, Optional, Union
 
-from sqlalchemy import Insert, Update, delete, func, insert, select, update
+from sqlalchemy import Insert, Update, delete, func, insert, or_, select, update
 
 from skyline_apiserver.types import Fn
 
 from .base import DB, inject_db
-from .models import RevokedToken, Settings
+from .models import (
+    DeletedExternalMessageBanners,
+    MessageBanners,
+    RevokedToken,
+    Settings,
+)
+
+
+MESSAGE_BANNER_COLUMNS = set(MessageBanners.c.keys())
+MESSAGE_BANNER_UPDATE_COLUMNS = MESSAGE_BANNER_COLUMNS - {"id", "created_at"}
 
 
 def check_db_connected(fn: Fn) -> Any:
@@ -114,3 +125,178 @@ def delete_setting(key: str) -> Any:
     with db.transaction():
         result = db.execute(query)
     return result
+
+
+def _project_region_conditions(
+    project_id: Optional[str] = None,
+    region: Optional[str] = None,
+) -> list:
+    conditions = []
+    if project_id:
+        conditions.append(
+            or_(
+                MessageBanners.c.project_id.is_(None),
+                MessageBanners.c.project_id == project_id,
+            )
+        )
+    if region:
+        conditions.append(
+            or_(
+                MessageBanners.c.region.is_(None),
+                MessageBanners.c.region == region,
+            )
+        )
+    return conditions
+
+
+@check_db_connected
+def list_message_banners(
+    project_id: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Any:
+    query = select(MessageBanners).order_by(MessageBanners.c.created_at.desc())
+    conditions = _project_region_conditions(project_id=project_id, region=region)
+    if conditions:
+        query = query.where(*conditions)
+    db = DB.get()
+    with db.transaction():
+        result = db.fetch_all(query)
+    return result
+
+
+@check_db_connected
+def list_active_message_banners(
+    project_id: Optional[str] = None,
+    region: Optional[str] = None,
+    message_type: Optional[str] = None,
+    global_only: bool = False,
+) -> Any:
+    now = datetime.now(timezone.utc)
+    conditions = [
+        MessageBanners.c.enabled.is_(True),
+        MessageBanners.c.expires_at > now,
+    ]
+    if message_type:
+        conditions.append(MessageBanners.c.type == message_type)
+    if global_only:
+        conditions.append(MessageBanners.c.project_id.is_(None))
+    elif project_id:
+        conditions.extend(_project_region_conditions(project_id=project_id))
+    if region:
+        conditions.extend(_project_region_conditions(region=region))
+    query = (
+        select(MessageBanners)
+        .where(*conditions)
+        .order_by(MessageBanners.c.created_at.desc())
+    )
+    db = DB.get()
+    with db.transaction():
+        result = db.fetch_all(query)
+    return result
+
+
+@check_db_connected
+def get_message_banner(banner_id: str) -> Any:
+    query = select(MessageBanners).where(MessageBanners.c.id == banner_id)
+    db = DB.get()
+    with db.transaction():
+        result = db.fetch_one(query)
+    return result
+
+
+@check_db_connected
+def create_message_banner(values: Dict[str, Any]) -> Any:
+    now = datetime.now(timezone.utc)
+    banner_id = values.get("id") or str(uuid.uuid4())
+    filtered_values = {
+        key: value for key, value in values.items() if key in MESSAGE_BANNER_COLUMNS
+    }
+    data = {
+        **filtered_values,
+        "id": banner_id,
+        "created_at": values.get("created_at") or now,
+        "updated_at": values.get("updated_at") or now,
+    }
+    query = insert(MessageBanners).values(**data)
+    get_query = select(MessageBanners).where(MessageBanners.c.id == banner_id)
+    db = DB.get()
+    with db.transaction():
+        db.execute(query)
+        result = db.fetch_one(get_query)
+    return result
+
+
+@check_db_connected
+def update_message_banner(banner_id: str, values: Dict[str, Any]) -> Any:
+    filtered_values = {
+        key: value for key, value in values.items() if key in MESSAGE_BANNER_UPDATE_COLUMNS
+    }
+    data = {
+        **filtered_values,
+        "updated_at": datetime.now(timezone.utc),
+    }
+    query = (
+        update(MessageBanners)
+        .where(MessageBanners.c.id == banner_id)
+        .values(**data)
+    )
+    get_query = select(MessageBanners).where(MessageBanners.c.id == banner_id)
+    db = DB.get()
+    with db.transaction():
+        db.execute(query)
+        result = db.fetch_one(get_query)
+    return result
+
+
+@check_db_connected
+def delete_message_banner(banner_id: str) -> Any:
+    get_query = select(MessageBanners).where(MessageBanners.c.id == banner_id)
+    delete_query = delete(MessageBanners).where(MessageBanners.c.id == banner_id)
+    db = DB.get()
+    with db.transaction():
+        result = db.fetch_one(get_query)
+        if (
+            result is not None
+            and result.source != "manual"
+            and result.source_id is not None
+        ):
+            deleted_query = select(DeletedExternalMessageBanners).where(
+                DeletedExternalMessageBanners.c.source == result.source,
+                DeletedExternalMessageBanners.c.source_id == result.source_id,
+            )
+            deleted_record = db.fetch_one(deleted_query)
+            if deleted_record is None:
+                db.execute(
+                    insert(DeletedExternalMessageBanners).values(
+                        source=result.source,
+                        source_id=result.source_id,
+                        region=result.region,
+                        deleted_at=datetime.now(timezone.utc),
+                    )
+                )
+        db.execute(delete_query)
+    return result
+
+
+@check_db_connected
+def sync_servicenow_ext_message_banner(values: Dict[str, Any]) -> Any:
+    source = values["source"]
+    source_id = values["source_id"]
+    deleted_query = select(DeletedExternalMessageBanners).where(
+        DeletedExternalMessageBanners.c.source == source,
+        DeletedExternalMessageBanners.c.source_id == source_id,
+    )
+    get_query = select(MessageBanners).where(
+        MessageBanners.c.source == source,
+        MessageBanners.c.source_id == source_id,
+    )
+    db = DB.get()
+    with db.transaction():
+        deleted_record = db.fetch_one(deleted_query)
+        if deleted_record is not None:
+            return None
+        existing = db.fetch_one(get_query)
+    if existing is None:
+        return create_message_banner(values)
+    values.pop("enabled", None)
+    return update_message_banner(existing.id, values)

--- a/skyline_apiserver/db/models.py
+++ b/skyline_apiserver/db/models.py
@@ -14,7 +14,17 @@
 
 from __future__ import annotations
 
-from sqlalchemy import JSON, Column, Integer, MetaData, String, Table
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+)
 
 METADATA = MetaData()
 
@@ -31,4 +41,33 @@ Settings = Table(
     METADATA,
     Column("key", String(length=128), nullable=False, index=True, unique=True),
     Column("value", JSON, nullable=True),
+)
+
+MessageBanners = Table(
+    "message_banners",
+    METADATA,
+    Column("id", String(length=36), nullable=False, primary_key=True),
+    Column("type", String(length=32), nullable=False, index=True),
+    Column("title", String(length=255), nullable=True),
+    Column("message", Text, nullable=False),
+    Column("impacted_service", String(length=255), nullable=True),
+    Column("start_at", DateTime(timezone=True), nullable=True, index=True),
+    Column("expires_at", DateTime(timezone=True), nullable=False, index=True),
+    Column("project_id", String(length=128), nullable=True, index=True),
+    Column("region", String(length=255), nullable=True, index=True),
+    Column("source", String(length=32), nullable=False, index=True),
+    Column("source_id", String(length=255), nullable=True, index=True),
+    Column("source_url", String(length=1024), nullable=True),
+    Column("enabled", Boolean, nullable=False, default=True),
+    Column("created_at", DateTime(timezone=True), nullable=False),
+    Column("updated_at", DateTime(timezone=True), nullable=False),
+)
+
+DeletedExternalMessageBanners = Table(
+    "deleted_external_message_banners",
+    METADATA,
+    Column("source", String(length=32), nullable=False, primary_key=True),
+    Column("source_id", String(length=255), nullable=False, primary_key=True),
+    Column("region", String(length=255), nullable=True, index=True),
+    Column("deleted_at", DateTime(timezone=True), nullable=False),
 )

--- a/skyline_apiserver/schemas/__init__.py
+++ b/skyline_apiserver/schemas/__init__.py
@@ -54,3 +54,10 @@ from .prometheus import (
     PrometheusQueryResult,
 )
 from .setting import Setting, Settings, UpdateSetting
+
+from .message_banner import (
+    CreateMessageBanner,
+    MessageBanner,
+    MessageBanners,
+    UpdateMessageBanner,
+)

--- a/skyline_apiserver/schemas/message_banner.py
+++ b/skyline_apiserver/schemas/message_banner.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MessageBannerBase(BaseModel):
+    type: Literal["maintenance", "notification"] = Field(
+        ..., description="Banner type"
+    )
+    title: Optional[str] = Field(None, description="Banner title")
+    message: str = Field(..., description="Banner message/details")
+    impacted_service: Optional[str] = Field(
+        None, description="Impacted service for maintenance banners"
+    )
+    start_at: Optional[datetime] = Field(
+        None, description="Start date/time in UTC"
+    )
+    expires_at: datetime = Field(
+        ..., description="Expiration date/time in UTC"
+    )
+    region: Optional[str] = Field(
+        None, description="Region. Null means all regions"
+    )
+    enabled: bool = Field(True, description="Whether banner is enabled")
+
+
+class CreateMessageBanner(MessageBannerBase):
+    """"""
+
+
+class UpdateMessageBanner(MessageBannerBase):
+    """"""
+
+
+class MessageBanner(MessageBannerBase):
+    id: str = Field(..., description="Banner ID")
+    project_id: Optional[str] = Field(
+        None, description="Project ID. Null means global/universal banner"
+    )
+    source: Literal["manual", "rackspace_status", "servicenow"] = Field(
+        "manual", description="Banner source"
+    )
+    source_id: Optional[str] = Field(
+        None, description="External source identifier"
+    )
+    source_url: Optional[str] = Field(
+        None, description="External source URL"
+    )
+    created_at: datetime = Field(..., description="Created time")
+    updated_at: datetime = Field(..., description="Updated time")
+
+
+class MessageBanners(BaseModel):
+    message_banners: List[MessageBanner] = Field(
+        ..., description="Message banners"
+    )

--- a/skyline_apiserver/utils/rackspace_status.py
+++ b/skyline_apiserver/utils/rackspace_status.py
@@ -1,0 +1,257 @@
+# Copyright 2021 99cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from datetime import datetime, timezone
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree
+
+import httpx
+
+from skyline_apiserver.log import LOG
+
+RACKSPACE_STATUS_FEED_URL = "https://rss.status.rackspace.com/snow/statusfeed"
+RACKSPACE_STATUS_PRODUCT = "OpenStack Flex"
+RACKSPACE_STATUS_TIMEOUT = 10.0
+
+DATETIME_RE = re.compile(r"\b20\d{2}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\b")
+OUTAGE_RE = re.compile(r"\bOUT\d+\b")
+CHANGE_RE = re.compile(r"\bCHG\d+\b")
+
+
+class _TextExtractor(HTMLParser):
+    block_tags = {
+        "br",
+        "div",
+        "li",
+        "p",
+        "section",
+        "table",
+        "tbody",
+        "td",
+        "th",
+        "thead",
+        "tr",
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.parts: List[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+        if tag in self.block_tags:
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+        if tag in self.block_tags:
+            self.parts.append("\n")
+
+    def handle_data(self, data):
+        if not self._skip_depth:
+            self.parts.append(data)
+
+    def get_text(self) -> str:
+        return unescape("".join(self.parts))
+
+
+def _env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def _float_env(name: str, default: float) -> float:
+    value = _env(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        LOG.warning(f"Ignoring invalid float value for {name}: {value}")
+        return default
+
+
+def _feed_url() -> str:
+    return _env("RACKSPACE_STATUS_FEED_URL", RACKSPACE_STATUS_FEED_URL)
+
+
+def _html_to_text(html: str) -> str:
+    parser = _TextExtractor()
+    parser.feed(html)
+    return parser.get_text()
+
+
+def _normalize_text(text: str) -> str:
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(
+        tzinfo=timezone.utc
+    )
+
+
+def _parse_date_range(text: str) -> Optional[tuple[datetime, datetime]]:
+    matches = DATETIME_RE.findall(text)
+    if len(matches) < 2:
+        return None
+    return _parse_datetime(matches[0]), _parse_datetime(matches[-1])
+
+
+def _split_title(title: str) -> List[str]:
+    return [part.strip() for part in title.split("|") if part.strip()]
+
+
+def _is_openstack_flex_item(title: str) -> bool:
+    parts = _split_title(title)
+    return bool(parts and parts[0].lower() == RACKSPACE_STATUS_PRODUCT.lower())
+
+
+def _title_region(title: str) -> Optional[str]:
+    parts = _split_title(title)
+    if len(parts) < 2:
+        return None
+    return parts[1]
+
+
+def _normalize_region(region: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", region.upper())
+
+
+def regions_match(title_region: Optional[str], expected_region: Optional[str]) -> bool:
+    if not expected_region:
+        return True
+    if not title_region:
+        return False
+
+    expected_region = _normalize_region(expected_region)
+    title_regions = [
+        _normalize_region(value)
+        for value in re.split(r"[,/]", title_region)
+        if value.strip()
+    ]
+    return expected_region in title_regions
+
+
+def _extract_source_id(text: str, link: Optional[str]) -> str:
+    outage_match = OUTAGE_RE.search(text)
+    if outage_match:
+        return outage_match.group(0)
+
+    change_match = CHANGE_RE.search(text)
+    if change_match:
+        return change_match.group(0)
+
+    raw_id = link or text
+    digest = hashlib.sha256(raw_id.encode("utf-8")).hexdigest()[:24]
+    return f"rss-{digest}"
+
+
+def _message_id(source_id: str) -> str:
+    return f"rackspace-status-{source_id}"
+
+
+def _message_type(text: str) -> str:
+    if "maintenance" in text.lower():
+        return "maintenance"
+    return "notification"
+
+
+def _message_text(title: str, description: str) -> str:
+    match = re.search(r"\bRackspace will\b", description, re.IGNORECASE)
+    message = description[match.start() :] if match else description
+    message = DATETIME_RE.sub("", message).strip()
+    return message or title
+
+
+def _item_text(item: ElementTree.Element, tag: str) -> Optional[str]:
+    value = item.findtext(tag)
+    if value is None:
+        return None
+    return value.strip()
+
+
+def _item_to_message_banner_values(
+    item: ElementTree.Element,
+) -> Optional[Dict[str, Any]]:
+    title = _item_text(item, "title") or ""
+    if not _is_openstack_flex_item(title):
+        return None
+
+    link = _item_text(item, "link")
+    raw_description = _item_text(item, "description") or ""
+    description = _normalize_text(_html_to_text(raw_description))
+    date_range = _parse_date_range(description)
+    if date_range is None:
+        LOG.warning(f"Skipping Rackspace status feed item without date range: {title}")
+        return None
+
+    start_at, expires_at = date_range
+    source_id = _extract_source_id(description, link)
+    item_region = _title_region(title)
+    return {
+        "id": _message_id(source_id),
+        "type": _message_type(f"{title}\n{description}"),
+        "title": title,
+        "message": _message_text(title, description),
+        "impacted_service": RACKSPACE_STATUS_PRODUCT,
+        "start_at": start_at,
+        "expires_at": expires_at,
+        "project_id": None,
+        "region": item_region,
+        "source": "rackspace_status",
+        "source_id": source_id,
+        "source_url": link,
+        "enabled": True,
+    }
+
+
+def fetch_rackspace_status_message_banner_values() -> List[Dict[str, Any]]:
+    """Fetch OpenStack Flex RSS feed items as DB-ready banner values."""
+
+    try:
+        with httpx.Client(
+            timeout=_float_env("RACKSPACE_STATUS_TIMEOUT", RACKSPACE_STATUS_TIMEOUT),
+        ) as client:
+            response = client.get(_feed_url())
+            response.raise_for_status()
+            root = ElementTree.fromstring(response.content)
+    except Exception as exc:
+        LOG.warning(f"Failed to fetch Rackspace status feed: {exc}")
+        return []
+
+    banner_values = []
+    seen_ids = set()
+    for item in root.findall("./channel/item"):
+        values = _item_to_message_banner_values(item)
+        if values is None or values["id"] in seen_ids:
+            continue
+
+        seen_ids.add(values["id"])
+        banner_values.append(values)
+
+    return banner_values


### PR DESCRIPTION
## Summary
Adds backend support for Skyline maintenance and notification banners.

## Changes

- Add message banner DB models and migration
- Add schemas for banner requests and responses
- Add admin CRUD APIs for manual maintenance and notification messages
- Add active banner API for logged-in users
- Sync OpenStack Flex messages from the Rackspace status RSS feed
- Filter displayed messages by project, region, enabled state, and expiration time
- Preserve expired messages for admin history